### PR TITLE
Newer nightly build, clearer README instructions for building.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rand =  { version = "0.8.5", optional = true }
 
 [profile.release]
 strip = true
-#rustflags = ["-C", "target-feature=+crt-static"]
+rustflags = ["-C", "target-feature=+crt-static"] # I found no problems with this.
 
 [package.metadata.winres]
 OriginalFilename = "giuroll.dll"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,11 @@ rand =  { version = "0.8.5", optional = true }
 
 [profile.release]
 strip = true
-rustflags = ["-C", "target-feature=+crt-static"] # I found no problems with this.
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[profile.dev]
+rustflags = ["-C", "target-feature=+crt-static"]
+
 
 [package.metadata.winres]
 OriginalFilename = "giuroll.dll"

--- a/README.md
+++ b/README.md
@@ -4,39 +4,35 @@ Is a network rollback mod for 東方非想天則 / Touhou 12.3 Hisoutensoku, whi
 
 Currently this is an early version, and might slightly increase instability, but will still significantly improve the netplay experience for almost all connections.  
 
-This repository also contains a stripped down version version of the crate [ilhook-rs](https://github.com/regomne/ilhook-rs), and a modified version of [mininip](https://github.com/SlooowAndFurious/mininip), all rights remain with their respective authors.
+This repository also contains a stripped down version of the crate [ilhook-rs](https://github.com/regomne/ilhook-rs), and a modified version of [mininip](https://github.com/SlooowAndFurious/mininip), all rights remain with their respective authors.
 
 ## Usage  
 
 ### For [SWRSToys](https://github.com/SokuDev/SokuMods/) users
-- navigate to your Hisoutensoku folder;
-- You should see a subfolder called `modules`, and a file called `SWRSToys.ini`
-- drop the giuroll folder from this zip into `modules`
-- add the following line into your `SWRSTOYS.ini`
-`giuroll=modules/giuroll/giuroll.dll`
-
-- find the following line
-`SWRSokuRoll=modules/SWRSokuRoll/SWRSokuRoll.dll`
-- add a `;` at the beginning of that line, making it
-`; SWRSokuRoll=modules/SWRSokuRoll/SWRSokuRoll.dll`
+1. Navigate to your Hisoutensoku folder. You should see a subfolder called `modules`, and a file called `SWRSToys.ini`.
+2. Drop the giuroll folder from this zip into `modules`. 
+3. Add the following line into your `SWRSTOYS.ini`
+```
+giuroll=modules/giuroll/giuroll.dll
+```
+4. Find the following line
+`SWRSokuRoll=modules/SWRSokuRoll/SWRSokuRoll.dll`.
+5. Add a `;` at the beginning of that line, making it
+```
+; SWRSokuRoll=modules/SWRSokuRoll/SWRSokuRoll.dll
+```
 
 ### For users without SWRSToys
-Mod can be loaded using the [Injector](/injector/).  
-The injector needs to be built from source, and placed alongside the dll and the ini, which can be found in official releases.
-- Start th123.exe 
-- Run the injector  
+See the [Injector](/injector/).  
 
-if sucessfull, you should see a message.  
-If the injector closes abruptly, contact me about it.
+**More information about the usage in game is available in the `installation and usage.txt` file inside the distributed zip**
 
-### More information about the usage in game is available in the `installation and usage.txt` file inside the distributed zip
+## Replay Rewind  
 
-## Replay rewind  
+In replay mode pressing `q` will start rewinding the replay, and the `A`, `S` and `D` keys will affect the rewind speed.  
+Pressing `z` will pause the replay, allowing you to move frame by frame, backwards or forwards via the `s` and `d` keys respectively.
 
-In replay mode pressing `q` will start rewinding, using keys that modify playback speed (A/S/D) will affect the rewind speed.  
-You can also pause the replay by pressing `z`. When the replay is paused this way you can move frame by frame, backwards or forwards, by using `s` and `d`
-
-## Use with [Tsk](https://wikiwiki.jp/thtools/%E5%A4%A9%E5%89%87%E8%A6%B3)
+## Usage with [Tsk](https://wikiwiki.jp/thtools/%E5%A4%A9%E5%89%87%E8%A6%B3)
 
 When used with Giuroll, Tsk may record one battle multiple times. A workaround is provided for it:
 
@@ -47,17 +43,22 @@ SWRS_ADDR_PBATTLEMGR = 0x0047579c
 ```
 
 ## Building from source
+The mod can be buit with `cargo` using the commands below.
+```bash
+rustup default nightly-2024-06-18-x86_64-pc-windows-msvc
+rustup component add rust-src --toolchain nightly-2024-06-18-x86_64-pc-windows-msvc 
+cargo +nightly-2024-06-18 build --target i686-win7-windows-msvc -Z build-std --release
+```
+For debugging/developmental purposes, you may build with the `--release` flag omitted. This will open a console window and show further details while the game is running. 
+<!--When building from source please remember to add the `--release`/`-r` flag.-->
 
-Mod can be buit with `cargo` using the `nightly-i686-pc-windows-msvc` toolchain.  
-When building from source please remember to add the `--release`/`-r` flag.
-
-## Common problems  
+## Common Problems  
 
 - Game doesn't load: check if the ini is valid according to the example ini provided in this repository, and is placed alongside the mod without any changes to it's name, and check for mod conflicts by disabling all other mods, and adding them back one by one.  
 - Failed to connect: either player is using an incompatible version of giuroll, or is not using it at all.  
 - Game desynced: I'm planning on adding a desync detector to make debugging desyncs easier, but since desyncs also occur with SokuRoll there is no guarantee they are caused solely by the rollback. If the desyncs are common, persists between game restarts, and are not appearing with Sokuroll, you can contact me about it.
 
-you can send feedback about any issues through:
+You can send feedback about any issues through:
 - [GitHub issues](https://github.com/Hagb/giuroll-hagb/issues), and/or
 - `@hagb_` in DMs or in a [hisoutensoku server](https://hisouten.koumakan.jp/wiki/Discord_Servers_List) through [Discord](https://discord.com).
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ SWRS_ADDR_PBATTLEMGR = 0x0047579c
 ## Building from source
 The mod can be buit with `cargo` using the commands below.
 ```bash
-rustup default nightly-2024-06-18-x86_64-pc-windows-msvc
+rustup default nightly-2024-06-18
 rustup component add rust-src --toolchain nightly-2024-06-18
 cargo +nightly-2024-06-18 build --target i686-win7-windows-msvc -Z build-std --release
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ giuroll=modules/giuroll/giuroll.dll
 ```
 
 ### For users without SWRSToys
-See the [Injector](/injector/).  
+See the [Injector](https://github.com/Hagb/giuroll-injector/tree/main).  
 
 **More information about the usage in game is available in the `installation and usage.txt` file inside the distributed zip**
 
@@ -46,7 +46,7 @@ SWRS_ADDR_PBATTLEMGR = 0x0047579c
 The mod can be buit with `cargo` using the commands below.
 ```bash
 rustup default nightly-2024-06-18-x86_64-pc-windows-msvc
-rustup component add rust-src --toolchain nightly-2024-06-18-x86_64-pc-windows-msvc 
+rustup component add rust-src --toolchain nightly-2024-06-18
 cargo +nightly-2024-06-18 build --target i686-win7-windows-msvc -Z build-std --release
 ```
 For debugging/developmental purposes, you may build with the `--release` flag omitted. This will open a console window and show further details while the game is running. 

--- a/ilhookmod/src/x86.rs
+++ b/ilhookmod/src/x86.rs
@@ -60,6 +60,7 @@ pub type JmpToAddrRoutine =
 pub type JmpToRetRoutine =
     unsafe extern "cdecl" fn(regs: *mut Registers, ori_func_ptr: usize, src_addr: usize) -> usize;
 
+/// TODO: add documentation - what is this?
 pub type JmpToRetEnumRoutine =
     unsafe extern "cdecl" fn(regs: *mut Registers, ori_func_ptr: usize, src_addr: usize) -> usize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2230,16 +2230,6 @@ pub extern "cdecl" fn is_likely_desynced() -> bool {
     unsafe { LIKELY_DESYNCED }
 }
 
-#[no_mangle]
-pub extern "cdecl" fn get_ping() -> i32 {
-    unsafe {
-        match NEXT_DRAW_PING {
-            Some(x) => x,
-            None => -1,
-        }
-    }
-}
-
 unsafe extern "stdcall" fn heap_alloc_override(heap: isize, flags: u32, s: usize) -> *mut c_void {
     let ret = HeapAlloc(HANDLE(heap), HEAP_FLAGS(flags), s);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2231,11 +2231,11 @@ pub extern "cdecl" fn is_likely_desynced() -> bool {
 }
 
 #[no_mangle]
-pub extern "cdecl" fn get_ping() -> *mut i32 {
+pub extern "cdecl" fn get_ping() -> i32 {
     unsafe {
         match NEXT_DRAW_PING {
-            Some(x) => Box::into_raw(Box::new(x)),
-            None => std::ptr::null_mut(),
+            Some(x) => x,
+            None => -1,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,10 @@ use sound::RollbackSoundManager;
 use windows::core::PCWSTR;
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::System::LibraryLoader::GetModuleFileNameW;
-use windows::Win32::System::Memory::{HEAP_FLAGS};
+use windows::Win32::System::Memory::HEAP_FLAGS;
+
+#[cfg(feature = "fillfree")]
+use windows::Win32::System::Memory::HEAP_ZERO_MEMORY;
 use windows::Win32::{
     Foundation::{GetLastError, HMODULE, HWND},
     Networking::WinSock::{closesocket, SOCKADDR, SOCKET},
@@ -2225,6 +2228,16 @@ static mut LIKELY_DESYNCED: bool = false;
 #[no_mangle]
 pub extern "cdecl" fn is_likely_desynced() -> bool {
     unsafe { LIKELY_DESYNCED }
+}
+
+#[no_mangle]
+pub extern "cdecl" fn get_ping() -> *mut i32 {
+    unsafe {
+        match NEXT_DRAW_PING {
+            Some(x) => Box::into_raw(Box::new(x)),
+            None => std::ptr::null_mut(),
+        }
+    }
 }
 
 unsafe extern "stdcall" fn heap_alloc_override(heap: isize, flags: u32, s: usize) -> *mut c_void {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,10 @@
-#![feature(pointer_is_aligned)]
-#![feature(abi_thiscall)]
 #![feature(let_chains)]
 #![feature(coroutines)]
 #![feature(iter_from_coroutine)]
 #![feature(anonymous_lifetime_in_impl_trait)]
 #![feature(panic_update_hook)]
 #![feature(panic_info_message)]
+#![feature(stmt_expr_attributes)]
 // we should manually and carefully avoid undefined behavior about
 // references to and any borrowing of static mut variables.
 // shuold be solved before updating to 2024 edition?
@@ -17,7 +16,7 @@ use std::panic;
 use std::{
     any::type_name,
     collections::HashMap,
-    ffi::{c_void, OsStr},
+    ffi::{c_void},
     mem::align_of,
     os::windows::prelude::OsStringExt,
     path::{Path, PathBuf},
@@ -47,7 +46,7 @@ use sound::RollbackSoundManager;
 use windows::core::PCWSTR;
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::System::LibraryLoader::GetModuleFileNameW;
-use windows::Win32::System::Memory::{HEAP_FLAGS, HEAP_ZERO_MEMORY};
+use windows::Win32::System::Memory::{HEAP_FLAGS};
 use windows::Win32::{
     Foundation::{GetLastError, HMODULE, HWND},
     Networking::WinSock::{closesocket, SOCKADDR, SOCKET},

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -462,7 +462,7 @@ pub unsafe fn dump_frame(
 
             m.push(read_addr(addr, size));
         }
-    };
+    }
 
     let ptr1 = read_addr(0x8985e8, 0x4);
     let first = get_ptr(&ptr1.content[0..4], 0);
@@ -709,7 +709,7 @@ pub unsafe fn dump_frame(
 
         let p11 = read_maybe_ring_buffer(player + 0x5fc);
         m.extend(p11.read_whole(0x10));
-    };
+    }
 
     let get_player = |p_game_manager: usize, offset: usize| {
         assert!(offset < 4);
@@ -953,7 +953,7 @@ impl LL3Holder {
             info!("ll4 is 0 ,painc");
             panic!("ll4 is 0");
         }
-        let c = || {
+        let c = #[coroutine] || {
             let last = read_ll4(self.ll4);
             let mut last_next = last.next;
             yield last;
@@ -983,7 +983,7 @@ impl LL3Holder {
 
     fn read_all<'a>(&'a self, additional_size: usize) -> impl Iterator<Item = ReadAddr> + 'a {
         //I think that readLL3 does not read itself, however, I will leave this here because it cannot hurt
-        let c = move || {
+        let c = #[coroutine] move || {
             yield self.to_addr();
             if self.listcount == 0 {
                 yield read_ll4(self.ll4).to_addr();


### PR DESCRIPTION
- Use newer cargo nightly build (nightly-2024-06-18),
- Resolves all warnings except documentation-related ones,
- Includes explicit build instructions in the README.